### PR TITLE
Update OpenWeatherMap http request to have API key

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func (w multiWeatherProvider) temperature(city string) (float64, error) {
 type openWeatherMap struct{}
 
 func (w openWeatherMap) temperature(city string) (float64, error) {
-	resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?q=" + city)
+	resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?APPID=YOUR_API_KEY&q=" + city)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This tweaks the URL structure for the OpenWeatherMap HTTP GET request to
have the APPID param with an API key that must be replaced with a real
API key.

The reason for this change is that starting on October 9, 2015,
OpenWeatherMap started to require an API key (a.k.a. APPID) to make
requests. See http://openweathermap.org/faq for more info on this
requirement and http://openweathermap.org/appid on using the APPID.

Here is the PR to update the corresponding article on howistart.org: https://github.com/howistart/howistart/pull/42

Fixes #3.
